### PR TITLE
Rails 2.3.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,22 @@
+source "http://rubygems.org"
+
+gem 'rails', '2.3.11'
+gem 'will_paginate'
+gem 'bluecloth'
+gem 'less'
+gem 'coderay'
+gem 'exception_notification'
+gem 'delayed_job'
+gem 'ruby-recaptcha'
+gem 'ruby-openid', '~> 2.0.4'
+gem 'RedCloth', :require => "redcloth"
+
+gem 'mail'
+gem 'mysql'
+
+group :development, :test do
+  gem 'rspec', '1.2.4'
+  gem 'rspec-rails', '1.2.4'
+  gem 'highline'
+  gem 'ruby-debug'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,7 @@ group :development, :test do
   gem 'highline'
   gem 'ruby-debug'
 end
+
+group :test do
+  gem 'sqlite3'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,81 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    RedCloth (4.2.7)
+    actionmailer (2.3.11)
+      actionpack (= 2.3.11)
+    actionpack (2.3.11)
+      activesupport (= 2.3.11)
+      rack (~> 1.1.0)
+    activerecord (2.3.11)
+      activesupport (= 2.3.11)
+    activeresource (2.3.11)
+      activesupport (= 2.3.11)
+    activesupport (2.3.11)
+    bluecloth (2.0.11)
+    coderay (0.9.7)
+    columnize (0.3.2)
+    daemons (1.0.10)
+    delayed_job (2.0.7)
+      activesupport (~> 2.0)
+      daemons (= 1.0.10)
+    exception_notification (2.3.3.0)
+    highline (1.6.1)
+    i18n (0.5.0)
+    less (1.2.21)
+      mutter (>= 0.4.2)
+      treetop (>= 1.4.2)
+    linecache (0.43)
+    mail (2.2.15)
+      activesupport (>= 2.3.6)
+      i18n (>= 0.4.0)
+      mime-types (~> 1.16)
+      treetop (~> 1.4.8)
+    mime-types (1.16)
+    mutter (0.5.3)
+    mysql (2.8.1)
+    polyglot (0.3.1)
+    rack (1.1.1)
+    rails (2.3.11)
+      actionmailer (= 2.3.11)
+      actionpack (= 2.3.11)
+      activerecord (= 2.3.11)
+      activeresource (= 2.3.11)
+      activesupport (= 2.3.11)
+      rake (>= 0.8.3)
+    rake (0.8.7)
+    rspec (1.2.4)
+    rspec-rails (1.2.4)
+      rack (>= 0.4.0)
+      rspec (= 1.2.4)
+    ruby-debug (0.10.4)
+      columnize (>= 0.1)
+      ruby-debug-base (~> 0.10.4.0)
+    ruby-debug-base (0.10.4)
+      linecache (>= 0.3)
+    ruby-openid (2.0.4)
+    ruby-recaptcha (1.0.2)
+    treetop (1.4.9)
+      polyglot (>= 0.3.1)
+    will_paginate (2.3.15)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  RedCloth
+  bluecloth
+  coderay
+  delayed_job
+  exception_notification
+  highline
+  less
+  mail
+  mysql
+  rails (= 2.3.11)
+  rspec (= 1.2.4)
+  rspec-rails (= 1.2.4)
+  ruby-debug
+  ruby-openid (~> 2.0.4)
+  ruby-recaptcha
+  will_paginate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,7 @@ GEM
       linecache (>= 0.3)
     ruby-openid (2.0.4)
     ruby-recaptcha (1.0.2)
+    sqlite3 (1.3.3)
     treetop (1.4.9)
       polyglot (>= 0.3.1)
     will_paginate (2.3.15)
@@ -78,4 +79,5 @@ DEPENDENCIES
   ruby-debug
   ruby-openid (~> 2.0.4)
   ruby-recaptcha
+  sqlite3
   will_paginate

--- a/README.rdoc
+++ b/README.rdoc
@@ -16,6 +16,8 @@ Then, execute the following commands on the project root:
 
 <tt>rake gems:install</tt>
 
+<tt>gem install highline ruby-debug mail mysql</tt>
+
 <tt>rake app:bootstrap</tt>
 
 You may be prompted to install a few extra gems.

--- a/README.rdoc
+++ b/README.rdoc
@@ -12,11 +12,13 @@ To bootstrap the project, you'll need to define database and email settings in t
 2. <tt>config/email.yml</tt> 
 3. <tt>config/recaptcha.rb</tt>
 
+This project now uses bundler to manage gem dependency. Make sure you have bundler installed:
+
+<tt>gem install bundler</tt>
+
 Then, execute the following commands on the project root:
 
-<tt>rake gems:install</tt>
-
-<tt>gem install highline ruby-debug mail mysql</tt>
+<tt>bundle install</tt>
 
 <tt>rake app:bootstrap</tt>
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,8 +27,8 @@ module ApplicationHelper
 
   def search_posts_title
     returning(params[:q].blank? ? I18n.t('txt.recent_posts', :default => 'Recent Posts') : I18n.t('txt.searching_for', :default => 'Searching for') + " '#{h params[:q]}'") do |title|
-      title << " " + I18n.t('txt.by_user', :default => 'by {{user}}', :user => h(@user.display_name)) if @user
-      title << " " + I18n.t('txt.in_forum', :default => 'in {{forum}}', :forum => h(@forum.name)) if @forum
+      title << " " + I18n.t('txt.by_user', :default => 'by %{user}', :user => h(@user.display_name)) if @user
+      title << " " + I18n.t('txt.in_forum', :default => 'in %{forum}', :forum => h(@forum.name)) if @forum
     end
   end
 

--- a/app/views/forums/_bad_topic.html.erb
+++ b/app/views/forums/_bad_topic.html.erb
@@ -20,10 +20,10 @@
     <td class="ca inv stat"><%= number_with_delimiter(topic.hits) %></td>
     <td class="lp">
         <abbr class="updated" title="<%= topic.last_updated_at.xmlschema %>">
-            <%= I18n.t 'txt.post_age', :when => time_ago_formatted(topic.last_updated_at), :default => "posted {{when}} ago" %>
+            <%= I18n.t 'txt.post_age', :when => time_ago_formatted(topic.last_updated_at), :default => "posted %{when} ago" %>
         </abbr>
         <% if topic.last_user -%>
-            <%= I18n.t 'txt.by_user', :default => 'by {{user}}', :user => link_to( topic.last_user.display_name, user_path(topic.last_user)) %>
+            <%= I18n.t 'txt.by_user', :default => 'by %{user}', :user => link_to( topic.last_user.display_name, user_path(topic.last_user)) %>
         <% end -%>
     </td>
 </tr>

--- a/app/views/forums/_topic.html.erb
+++ b/app/views/forums/_topic.html.erb
@@ -20,10 +20,10 @@
             <td class="ca inv stat"><%= number_with_delimiter(topic.hits) %></td>
             <td class="lp">
                 <abbr class="updated" title="<%= topic.last_updated_at.xmlschema %>">
-                    <%= I18n.t 'txt.post_age', :when => time_ago_formatted(topic.last_updated_at), :default => "posted {{when}} ago" %>
+                    <%= I18n.t 'txt.post_age', :when => time_ago_formatted(topic.last_updated_at), :default => "posted %{when} ago" %>
                 </abbr>
                 <% if topic.last_user -%>
-                    <%= I18n.t 'txt.by_user', :default => 'by {{user}}', :user => link_to( topic.last_user.display_name, user_path(topic.last_user)) %>
+                    <%= I18n.t 'txt.by_user', :default => 'by %{user}', :user => link_to( topic.last_user.display_name, user_path(topic.last_user)) %>
                 <% end -%>
             </td>
         </tr>

--- a/app/views/forums/index.html.erb
+++ b/app/views/forums/index.html.erb
@@ -49,8 +49,8 @@
 
     <td class="inv lp">
       <% if forum.recent_post -%>
-        <%= I18n.t 'txt.post_age', :when => time_ago_formatted(forum.recent_post.created_at), :default => "posted {{when}} ago" %><br />
-        <strong><%= I18n.t 'txt.by_user', :default => 'by {{user}}', :user => "#{h(forum.recent_post.user.display_name)}" %></strong>
+        <%= I18n.t 'txt.post_age', :when => time_ago_formatted(forum.recent_post.created_at), :default => "posted %{when} ago" %><br />
+        <strong><%= I18n.t 'txt.by_user', :default => 'by %{user}', :user => "#{h(forum.recent_post.user.display_name)}" %></strong>
         <span>(<%= link_to I18n.t('txt.view', :default => 'view'), forum_topic_path(forum, forum.recent_post.topic, :page => forum.recent_post.topic.last_page, :anchor => dom_id(forum.recent_post)) %>)</span>
       <% end -%>
     </td>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,7 +4,7 @@
 <% if params[:q].blank? -%>
   <%= @page_title %>
 <% else -%>
-  <%= I18n.t 'txt.search_results_for_searchterm', :default => "Search results for '{{searchterm}}'", :searchterm => h(params[:q]) %>
+  <%= I18n.t 'txt.search_results_for_searchterm', :default => "Search results for '%{searchterm}'", :searchterm => h(params[:q]) %>
 <% end -%>
 </h1>
 <p class="subtitle">
@@ -27,7 +27,7 @@
     <span class="posts"><%= I18n.t 'txt.count_posts', :count => @users[post.user_id].posts.size, :num => number_with_delimiter(@users[post.user_id].posts.size) %></span>   
 	<div class="date">
       <abbr class="updated" title="<%= post.created_at.xmlschema %>">
-      <%= I18n.t 'txt.post_age', :when => time_ago_formatted(post.created_at), :default => 'posted {{when}} ago' %>
+      <%= I18n.t 'txt.post_age', :when => time_ago_formatted(post.created_at), :default => 'posted %{when} ago' %>
       </abbr>
     </div>
   </td>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -5,7 +5,7 @@
 
 <h1 id="new_topic"><%= I18n.t 'txt.new_topic', :default => 'New topic' %></h1>
 <%if logged_in?%>
-  <p class="subtitle"><%= I18n.t 'txt.by_user', :default => 'by {{user}}', :user => current_user.display_name %></p>
+  <p class="subtitle"><%= I18n.t 'txt.by_user', :default => 'by %{user}', :user => current_user.display_name %></p>
 <%end%>
 <br class="clear" />
 

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -76,7 +76,7 @@
                     <div class="date">
                         <a href="#<%= dom_id post %>" rel="bookmark">
                             <abbr class="updated" title="<%= post.created_at.xmlschema %>">
-                                <%= I18n.t 'txt.post_age', :when => time_ago_formatted(post.created_at), :default => "posted {{when}} ago" %>
+                                <%= I18n.t 'txt.post_age', :when => time_ago_formatted(post.created_at), :default => "posted %{when} ago" %>
                             </abbr>
                         </a><!-- bookmark-->
                     </div><!-- date -->

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :right do %>
 
   <h5><%=  I18n.t 'txt.views_users.avatars_title', :default => 'Avatars' %></h5>
-  <p><%= I18n.t 'txt.views_users.gravatar_notice', :default => 'To have your very own avatar displayed on this forum visit {{gravatar}} and sign up for a free gravatar.', :gravatar => '<a href="http://www.gravatar.com/" title="Gravatar - Globally Recognized Avatars">Gravatar</a>' %></p>
+  <p><%= I18n.t 'txt.views_users.gravatar_notice', :default => 'To have your very own avatar displayed on this forum visit %{gravatar} and sign up for a free gravatar.', :gravatar => '<a href="http://www.gravatar.com/" title="Gravatar - Globally Recognized Avatars">Gravatar</a>' %></p>
 
   <% if current_user.admin? %>
     <% form_for @user, :url => make_admin_user_path(@user) do |f| %>
@@ -20,7 +20,7 @@
 
 <h1><%= I18n.t 'txt.views_users.settings', :default => 'Settings' %></h1>
 
-<p class="subtitle"><%= I18n.t 'txt.views_users.for_user', :default => 'for {{user}}', :user => @user.display_name %>
+<p class="subtitle"><%= I18n.t 'txt.views_users.for_user', :default => 'for %{user}', :user => @user.display_name %>
 	<% if @user.login!=@user.display_name %>
 	(<%= @user.login %>)
 	<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,7 +18,7 @@
     <%unless @user.twitter.blank? -%>
       <strong><%= I18n.t 'txt.twitter', :default => 'Twitter' %></strong> <%= sanitize link_to("@" + @user.twitter, "http://twitter.com/" + @user.twitter) %><br />
     <% end -%>
-  <%= I18n.t('txt.user_since', :default => 'User since {{date}}', :date => I18n.l(@user.created_at.to_s(:long).to_date)).capitalize %>
+  <%= I18n.t('txt.user_since', :default => 'User since %{date}', :date => I18n.l(@user.created_at.to_s(:long).to_date)).capitalize %>
 </small>
 <hr style="clear:both" />
   <span class="bio"><%= @user.bio_html %></span>

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -110,5 +110,19 @@ module Rails
   end
 end
 
+class Rails::Boot
+  def run
+    load_initializer
+
+    Rails::Initializer.class_eval do
+      def load_gems
+        @bundler_loaded ||= Bundler.require :default, Rails.env
+      end
+    end
+
+    Rails::Initializer.run(:set_load_path)
+  end
+end
+
 # All that for this:
 Rails.boot!

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -44,6 +44,7 @@ module Rails
     def load_initializer
       require "#{RAILS_ROOT}/vendor/rails/railties/lib/initializer"
       Rails::Initializer.run(:install_gem_spec_stubs)
+      Rails::GemDependency.add_frozen_gem_path
     end
   end
 
@@ -61,8 +62,12 @@ module Rails
         gem 'rails'
       end
     rescue Gem::LoadError => load_error
-      $stderr.puts %(Missing the Rails #{version} gem. Please `gem install -v=#{version} rails`, update your RAILS_GEM_VERSION setting in config/environment.rb for the Rails version you do have installed, or comment out RAILS_GEM_VERSION to use the latest version installed.)
-      exit 1
+      if load_error.message =~ /Could not find RubyGem rails/
+        STDERR.puts %(Missing the Rails #{version} gem. Please `gem install -v=#{version} rails`, update your RAILS_GEM_VERSION setting in config/environment.rb for the Rails version you do have installed, or comment out RAILS_GEM_VERSION to use the latest version installed.)
+        exit 1
+      else
+        raise
+      end
     end
 
     class << self
@@ -81,8 +86,8 @@ module Rails
       end
 
       def load_rubygems
+        min_version = '1.3.2'
         require 'rubygems'
-        min_version = '1.3.1'
         unless rubygems_version >= min_version
           $stderr.puts %Q(Rails requires RubyGems >= #{min_version} (you have #{rubygems_version}). Please `gem update --system` and try again.)
           exit 1

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -5,7 +5,7 @@
 # ENV['RAILS_ENV'] ||= 'production'
 
 # Specifies gem version of Rails to use when vendor/rails is not present
-RAILS_GEM_VERSION = '2.3.3' unless defined? RAILS_GEM_VERSION
+RAILS_GEM_VERSION = '2.3.11' unless defined? RAILS_GEM_VERSION
 
 # Bootstrap the Rails environment, frameworks, and default configuration
 require File.join(File.dirname(__FILE__), 'boot')

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -17,15 +17,6 @@ Rails::Initializer.run do |config|
   # -- all .rb files in that directory are automatically loaded.
   # See Rails::Configuration for more options.
 
-  config.gem "mislav-will_paginate", :lib => "will_paginate", :source => "http://gems.github.com"
-  config.gem "RedCloth", :lib => "redcloth"
-  config.gem "bluecloth"
-  config.gem "less"
-  config.gem "coderay"
-  config.gem "exception_notification"
-  config.gem "delayed_job"
-  config.gem "ruby-recaptcha"
-
   # Skip frameworks you're not going to use (only works if using vendor/rails).
   # To use Rails without a database, you must remove the Active Record framework
   # config.frameworks -= [ :active_record, :active_resource, :action_mailer ]
@@ -47,7 +38,7 @@ Rails::Initializer.run do |config|
   # Make sure the secret is at least 30 characters and all random,
   # no regular words or you'll be exposed to dictionary attacks.
   config.action_controller.session = {
-    :session_key => '_altered_beast_session',
+    :key => '_altered_beast_session',
     :secret      => 'f471415647be47dc513d5e345ca4e582a8f99f388e0ccd46a2cdac51e2cd27c8e8b4d7dbba379cf661d4857afaf6b1867489bbc5e16b5fb14d2c3e53df64c272'
   }
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -20,6 +20,3 @@ config.action_controller.allow_forgery_protection    = false
 # The :test delivery method accumulates sent emails in the
 # ActionMailer::Base.deliveries array.
 config.action_mailer.delivery_method = :test
-
-config.gem 'rspec', :lib => 'spec', :version => '1.2.4'
-config.gem 'rspec-rails', :lib => 'spec/rails', :version => '1.2.4'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -29,35 +29,35 @@
       less_than_x_seconds:
         zero: 'weniger als 1 Sekunde'
         one: '1 Sekunde'
-        other: '{{count}} Sekunden'
+        other: '%{count} Sekunden'
       x_seconds:
         one: '1 Sekunde'
-        other: '{{count}} Sekunden'
+        other: '%{count} Sekunden'
       less_than_x_minutes:
         zero: 'weniger als 1 Minute'
         one: 'eine Minute'
-        other: '{{count}} Minuten'
+        other: '%{count} Minuten'
       x_minutes:
         one: '1 Minute'
-        other: '{{count}} Minuten'
+        other: '%{count} Minuten'
       about_x_hours:
         one: 'etwa 1 Stunde'
-        other: '{{count}} Stunden'
+        other: '%{count} Stunden'
       x_days:
         one: '1 Tag'
-        other: '{{count}} Tagen'
+        other: '%{count} Tagen'
       about_x_months:
         one: 'etwa 1 Monat'
-        other: '{{count}} Monate'
+        other: '%{count} Monate'
       x_months:
         one: '1 Monat'
-        other: '{{count}} Monate'
+        other: '%{count} Monate'
       about_x_years:
         one: 'etwa 1 Jahr'
-        other: '{{count}} Jahre'
+        other: '%{count} Jahre'
       over_x_years:
         one: 'mehr als 1 Jahr'
-        other: '{{count}} Jahre'
+        other: '%{count} Jahre'
       
   number:
     format:
@@ -71,7 +71,7 @@
         
   active_record:
     error:
-      header_message: ["Konnte das {{object_name}} Objekt nicht speichern: 1 Fehler.", "Konnte das {{object_name}} Objekt nicht speichern: {{count}} Fehler."]
+      header_message: ["Konnte das %{object_name} Objekt nicht speichern: 1 Fehler.", "Konnte das %{object_name} Objekt nicht speichern: %{count} Fehler."]
       message: "Bitte überprüfen Sie die folgenden Felder:"
     error_messages:
       inclusion: "ist kein gültiger Wert"
@@ -81,16 +81,16 @@
       accepted: "muss akzeptiert werden"
       empty: "muss ausgefüllt werden"
       blank: "muss ausgefüllt werden"
-      too_long: "ist zu lang (nicht mehr als {{count}} Zeichen)"
-      too_short: "ist zu kurz (nicht weniger als {{count}} Zeichen)"
-      wrong_length: "hat die falsche Länge (muss genau {{count}} Zeichen haben)"
+      too_long: "ist zu lang (nicht mehr als %{count} Zeichen)"
+      too_short: "ist zu kurz (nicht weniger als %{count} Zeichen)"
+      wrong_length: "hat die falsche Länge (muss genau %{count} Zeichen haben)"
       taken: "ist bereits vergeben"
       not_a_number: "ist keine Zahl"
-      greater_than: "muss größer als {{count}} sein"
-      greater_than_or_equal_to: "muss größer oder gleich {{count}} sein"
-      equal_to: "muss genau {{count}} sein"
-      less_than: "muss kleiner als {{count}} sein"
-      less_than_or_equal_to: "muss kleiner oder gleich {{count}} sein"
+      greater_than: "muss größer als %{count} sein"
+      greater_than_or_equal_to: "muss größer oder gleich %{count} sein"
+      equal_to: "muss genau %{count} sein"
+      less_than: "muss kleiner als %{count} sein"
+      less_than_or_equal_to: "muss kleiner oder gleich %{count} sein"
       odd: "muss ungerade sein"
       even: "muss gerade sein"
 
@@ -129,7 +129,7 @@
     user_is_administrator: Administrator
     user_is_moderator: Moderator
 
-    user_since: Benutzer seit {{date}}
+    user_since: Benutzer seit %{date}
     monitored: monitored
     locked: gesperrt
     locked_topic: Dieses Thema ist gesperrt.
@@ -139,15 +139,15 @@
     recent_posts: Neue Beiträge
     no_recent_activity: Keine neuen Aktivitäten
     show_recent_posts: Neueste Themen anzeigen
-    search_results_for_searchterm: "Suchergebnis für &raquo;{{searchterm}}&laquo;"
+    search_results_for_searchterm: "Suchergebnis für &raquo;%{searchterm}&laquo;"
     goto_last_page: zur letzten Seite
 
     new_topic: Neues Thema
     post_topic: Thema starten
     reply_to_topic: Neuen Beitrag zu diesem Thema schreiben
 
-    by_user: "von {{user}}"
-    page_nr: "Seite {{nr}}"
+    by_user: "von %{user}"
+    page_nr: "Seite %{nr}"
 
     login: Login
     login_name: Login
@@ -180,7 +180,7 @@
 
       admin_and_moderation: Admin & Moderation
       remove_moderated_forum: Der Benutzer kann folgende Foren moderieren. Anklicken um dessen Moderation zu löschen.
-      remove_user_as_moderator: Benutzer als Moderator von &raquo;{{forum}}&laquo; entfernen?
+      remove_user_as_moderator: Benutzer als Moderator von &raquo;%{forum}&laquo; entfernen?
       add_as_moderator: Als Moderator hinzufügen
       user_is_an_administrator: User ist ein Administrator
       suspend_user_account: Benutzer sperren
@@ -192,44 +192,44 @@
     count_forums:
       zero: "kein Forum"
       one: "1 Forum"
-      other: "{{num}} Foren"
+      other: "%{num} Foren"
 
     count_users:
       zero: "kein Benutzer"
       one: "1 Benutzer"
-      other: "{{num}} Benutzer"
+      other: "%{num} Benutzer"
 
     count_users_active:
       zero: "kein aktiver Benutzer"
       one: "1 aktiver Benutzer"
-      other: "{{num}} aktive Benutzer"
+      other: "%{num} aktive Benutzer"
 
     count_users_lurking:
       zero: "kein nur-lesender Benutzer"
       one: "1 nur-lesender Benutzer"
-      other: "{{num}} nur-lesende Benutzer"
+      other: "%{num} nur-lesende Benutzer"
 
     count_voices:
       zero: "kein Teilnehmer"
       one: "1 Teilnehmer"
-      other: "{{num}} Teilnehmer"
+      other: "%{num} Teilnehmer"
 
     count_topics:
       zero: "kein Thema"
       one: "1 Thema"
-      other: "{{num}} Themen"
+      other: "%{num} Themen"
 
     count_posts:
       zero: "kein Beitrag"
       one: "1 Beitrag"
-      other: "{{num}} Beiträge"
+      other: "%{num} Beiträge"
 
     count_posts_found:
       zero: "kein Beitrag gefunden"
       one: "1 Beitrag gefunden"
-      other: "{{count}} Beiträge gefunden"
+      other: "%{count} Beiträge gefunden"
 
-    post_age: "vor {{when}}"
+    post_age: "vor %{when}"
 
     views_sites:
       title: Seiten
@@ -251,9 +251,9 @@
       search_title: suchen
 
       avatars_title: Avatar
-      gravatar_notice: Damit Ihr eigener Avatar angezeigt wird, melden Sie sich bitte kostenlos bei {{gravatar}} an und hinterlegen Sie dort Ihren ganz persönlichen Avatar.
+      gravatar_notice: Damit Ihr eigener Avatar angezeigt wird, melden Sie sich bitte kostenlos bei %{gravatar} an und hinterlegen Sie dort Ihren ganz persönlichen Avatar.
       settings: Einstellungen
-      for_user: für Benutzer {{user}}
+      for_user: für Benutzer %{user}
       change_email_or_password: Email oder Passwort ändern
       update_profile: Profil aktualisieren
 

--- a/config/locales/en.rb
+++ b/config/locales/en.rb
@@ -23,16 +23,16 @@
     :datetime => {
       :distance_in_words => {
         :half_a_minute       => 'half a minute',
-        :less_than_x_seconds => {:zero => 'less than 1 second', :one => '1 second', :other => '{{count}} seconds'},
-        :x_seconds           => {:one => '1 second', :other => '{{count}} seconds'},
-        :less_than_x_minutes => {:zero => 'less than a minute', :one => '1 minute', :other => '{{count}} minutes'},
-        :x_minutes           => {:one => "1 minute", :other => "{{count}} minutes"},
-        :about_x_hours       => {:one => 'about 1 hour', :other => '{{count}} hours'},
-        :x_days              => {:one => '1 day', :other => '{{count}} days'},
-        :about_x_months      => {:one => 'about 1 month', :other => '{{count}} months'},
-        :x_months            => {:one => '1 month', :other => '{{count}} months'},
-        :about_x_years       => {:one => 'about 1 year', :other => '{{count}} years'},
-        :over_x_years        => {:one => 'over 1 year', :other => '{{count}} years'}
+        :less_than_x_seconds => {:zero => 'less than 1 second', :one => '1 second', :other => '%{count} seconds'},
+        :x_seconds           => {:one => '1 second', :other => '%{count} seconds'},
+        :less_than_x_minutes => {:zero => 'less than a minute', :one => '1 minute', :other => '%{count} minutes'},
+        :x_minutes           => {:one => "1 minute", :other => "%{count} minutes"},
+        :about_x_hours       => {:one => 'about 1 hour', :other => '%{count} hours'},
+        :x_days              => {:one => '1 day', :other => '%{count} days'},
+        :about_x_months      => {:one => 'about 1 month', :other => '%{count} months'},
+        :x_months            => {:one => '1 month', :other => '%{count} months'},
+        :about_x_years       => {:one => 'about 1 year', :other => '%{count} years'},
+        :over_x_years        => {:one => 'over 1 year', :other => '%{count} years'}
       }
     },
  
@@ -55,7 +55,7 @@
     # Active Record
     :active_record => {
       :error => {
-        :header_message => ["Couldn't save this {{object_name}}: 1 error", "Couldn't save this {{object_name}}: {{count}} errors."],
+        :header_message => ["Couldn't save this %{object_name}: 1 error", "Couldn't save this %{object_name}: %{count} errors."],
         :message => "Please check the following fields:"
       }
     },
@@ -68,16 +68,16 @@
         :accepted  => "must be accepted",
         :empty => "must be given",
         :blank => "must be given",
-        :too_long => "is too long (no more than {{count}} characters)",
-        :too_short => "is too short (no less than {{count}} characters)",
-        :wrong_length => "is not the right length (must be {{count}} characters)",
+        :too_long => "is too long (no more than %{count} characters)",
+        :too_short => "is too short (no less than %{count} characters)",
+        :wrong_length => "is not the right length (must be %{count} characters)",
         :taken => "is not available",
         :not_a_number => "is not a number",
-        :greater_than => "must be greater than {{count}}",
-        :greater_than_or_equal_to => "must be greater than or equal to {{count}}",
-        :equal_to => "must be equal to {{count}}",
-        :less_than => "must be less than {{count}}",
-        :less_than_or_equal_to => "must be less than or equal to {{count}}",
+        :greater_than => "must be greater than %{count}",
+        :greater_than_or_equal_to => "must be greater than or equal to %{count}",
+        :equal_to => "must be equal to %{count}",
+        :less_than => "must be less than %{count}",
+        :less_than_or_equal_to => "must be less than or equal to %{count}",
         :odd => "must be odd",
         :even => "must be even"
       }
@@ -96,9 +96,9 @@
       },
       :about => {
         :title => "About this demo app",
-        :author => "This demo app was written by {{mail_1}}.",
-        :feedback => "If you have any feedback, please feel free to drop me a line. Also visit {{blog_href}} where I regularly blog about Rails and other stuff.",
-        :licence => "This demo app and all its contents are licensed under the {{licence_href}}. If you want to use it in ways prohibited by this license, please contact me and ask my permission."
+        :author => "This demo app was written by %{mail_1}.",
+        :feedback => "If you have any feedback, please feel free to drop me a line. Also visit %{blog_href} where I regularly blog about Rails and other stuff.",
+        :licence => "This demo app and all its contents are licensed under the %{licence_href}. If you want to use it in ways prohibited by this license, please contact me and ask my permission."
       },
       :active_record => {
         :too_lazy => "No examples here since I'm too lazy to think of attributes to show <strong>all</strong> custom error messages. ;-)",
@@ -113,17 +113,17 @@
       },
       :index => {
         :others => "others",
-        :introduction => "Lately, a lot of work has been done by {{sven_blog}} and {{sven_github}} to facilitate future internationalization and localization of Rails.",
+        :introduction => "Lately, a lot of work has been done by %{sven_blog} and %{sven_github} to facilitate future internationalization and localization of Rails.",
         :story_so_far => "This demo app tries to show you how you can use the features that have been implemented so far to localize big parts of your Rails application."
       },
       :number_helper => {
-        :note_one => "Note: <code>number_to_phone</code> hasn't been localized yet and probably never will be - at least not in core. Look out for new internationalization/localization plugins like a new version of {{globalize}} as they will probably support stuff like that.",
+        :note_one => "Note: <code>number_to_phone</code> hasn't been localized yet and probably never will be - at least not in core. Look out for new internationalization/localization plugins like a new version of %{globalize} as they will probably support stuff like that.",
         :note_two => "Another note: <code>number_to_currency</code>, <code>number_to_percentage</code> and <code>number_to_human_size</code> all use <code>number_with_precision</code> internally and <code>number_with_precision</code> uses <code>number_with_delimiter</code> internally."
       },
       :setup => {
         :freezing_edge_and_adding => "Freezing Edge and installing the localized_dates plugin",
         :you_need_to_be_on_edge => "You need to be on Edge Rails in order to use the Rails i18n features:",
-        :date_time_formats => "For date and time formats, you also need to install the {{localized_dates_link}}:",
+        :date_time_formats => "For date and time formats, you also need to install the %{localized_dates_link}:",
         :config_locale => "Configuring the locale",
         :best_place => "The best place to put your locale configuration, in my opinion, is <code>config/locales</code>. The localized_dates plugin will copy two locales, en-US and de-AT, in this directory. You can extend or modify them and also create new locales.",
         :locale => "Here's the demo locale that was used for this demo application:",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,35 +33,35 @@
       less_than_x_seconds:
         zero: 'less than 1 second'
         one: '1 second'
-        other: '{{count}} seconds'
+        other: '%{count} seconds'
       x_seconds:
         one: '1 second'
-        other: '{{count}} seconds'
+        other: '%{count} seconds'
       less_than_x_minutes:
         zero: 'less than a minute'
         one: '1 minute'
-        other: '{{count}} minutes'
+        other: '%{count} minutes'
       x_minutes:
         one: '1 minute'
-        other: '{{count}} minutes'
+        other: '%{count} minutes'
       about_x_hours:
         one: 'about 1 hour'
-        other: '{{count}} hours'
+        other: '%{count} hours'
       x_days:
         one: '1 day'
-        other: '{{count}} days'
+        other: '%{count} days'
       about_x_months:
         one: 'about 1 month'
-        other: '{{count}} months'
+        other: '%{count} months'
       x_months:
         one: '1 month'
-        other: '{{count}} months'
+        other: '%{count} months'
       about_x_years:
         one: 'about 1 year'
-        other: '{{count}} years'
+        other: '%{count} years'
       over_x_years:
         one: 'over 1 year'
-        other: '{{count}} years'
+        other: '%{count} years'
       
   number:
     format:
@@ -76,7 +76,7 @@
         
   active_record:
     error:
-      header_message: ["Couldn't save this {{object_name}}: 1 error", "Couldn't save this {{object_name}}: {{count}} errors."]
+      header_message: ["Couldn't save this %{object_name}: 1 error", "Couldn't save this %{object_name}: %{count} errors."]
       message: "Please check the following fields:"
     error_messages:
       inclusion: "is not included in the list"
@@ -86,16 +86,16 @@
       accepted: "must be accepted"
       empty: "must be given"
       blank: "must be given"
-      too_long: "is too long (no more than {{count}} characters)"
-      too_short: "is too short (no less than {{count}} characters)"
-      wrong_length: "is not the right length (must be {{count}} characters)"
+      too_long: "is too long (no more than %{count} characters)"
+      too_short: "is too short (no less than %{count} characters)"
+      wrong_length: "is not the right length (must be %{count} characters)"
       taken: "is not available"
       not_a_number: "is not a number"
-      greater_than: "must be greater than {{count}}"
-      greater_than_or_equal_to: "must be greater than or equal to {{count}}"
-      equal_to: "must be equal to {{count}}"
-      less_than: "must be less than {{count}}"
-      less_than_or_equal_to: "must be less than or equal to {{count}}"
+      greater_than: "must be greater than %{count}"
+      greater_than_or_equal_to: "must be greater than or equal to %{count}"
+      equal_to: "must be equal to %{count}"
+      less_than: "must be less than %{count}"
+      less_than_or_equal_to: "must be less than or equal to %{count}"
       odd: "must be odd"
       even: "must be even"
 
@@ -103,35 +103,35 @@
     count_forums:
       zero: "no forum"
       one: "1 forum"
-      other: "{{num}} forums"
+      other: "%{num} forums"
     count_users:
       zero: "no users"
       one: "1 user"
-      other: "{{num}} users"
+      other: "%{num} users"
     count_users_active:
       zero: "no active users"
       one: "1 active user"
-      other: "{{num}} active users"
+      other: "%{num} active users"
     count_users_lurking:
       zero: "no lurking users"
       one: "1 lurking user"
-      other: "{{num}} lurking users"
+      other: "%{num} lurking users"
     count_voices:
       zero: "no voices"
       one: "1 voice"
-      other: "{{num}} voices"
+      other: "%{num} voices"
     count_topics:
       zero: "no topics"
       one: "1 topic"
-      other: "{{num}} topics"
+      other: "%{num} topics"
     count_posts:
       zero: "no posts"
       one: "1 post"
-      other: "{{num}} posts"
+      other: "%{num} posts"
     count_posts_found:
       zero: "no posts found"
       one: "1 post found"
-      other: "{{count}} posts found"
+      other: "%{count} posts found"
 
     views_users:
       email_directions: Enter your email, and a brand new login key will be sent to you.  Click the link in the email to log in, and then change your password.

--- a/config/locales/pt-BR.rb
+++ b/config/locales/pt-BR.rb
@@ -29,16 +29,16 @@
     :datetime => {
       :distance_in_words => {
         :half_a_minute       => 'half a minute',
-        :less_than_x_seconds => {:zero => 'less than 1 second', :one => '1 second', :other => '{{count}} seconds'},
-        :x_seconds           => {:one => '1 second', :other => '{{count}} seconds'},
-        :less_than_x_minutes => {:zero => 'less than a minute', :one => '1 minute', :other => '{{count}} minutes'},
-        :x_minutes           => {:one => "1 minute", :other => "{{count}} minutes"},
-        :about_x_hours       => {:one => 'about 1 hour', :other => '{{count}} hours'},
-        :x_days              => {:one => '1 day', :other => '{{count}} days'},
-        :about_x_months      => {:one => 'about 1 month', :other => '{{count}} months'},
-        :x_months            => {:one => '1 month', :other => '{{count}} months'},
-        :about_x_years       => {:one => 'about 1 year', :other => '{{count}} years'},
-        :over_x_years        => {:one => 'over 1 year', :other => '{{count}} years'}
+        :less_than_x_seconds => {:zero => 'less than 1 second', :one => '1 second', :other => '%{count} seconds'},
+        :x_seconds           => {:one => '1 second', :other => '%{count} seconds'},
+        :less_than_x_minutes => {:zero => 'less than a minute', :one => '1 minute', :other => '%{count} minutes'},
+        :x_minutes           => {:one => "1 minute", :other => "%{count} minutes"},
+        :about_x_hours       => {:one => 'about 1 hour', :other => '%{count} hours'},
+        :x_days              => {:one => '1 day', :other => '%{count} days'},
+        :about_x_months      => {:one => 'about 1 month', :other => '%{count} months'},
+        :x_months            => {:one => '1 month', :other => '%{count} months'},
+        :about_x_years       => {:one => 'about 1 year', :other => '%{count} years'},
+        :over_x_years        => {:one => 'over 1 year', :other => '%{count} years'}
       }
     },
 
@@ -86,9 +86,9 @@
       },
       :about => {
         :title => "About this demo app",
-        :author => "This demo app was written by {{mail_1}}.",
-        :feedback => "If you have any feedback, please feel free to drop me a line. Also visit {{blog_href}} where I regularly blog about Rails and other stuff.",
-        :licence => "This demo app and all its contents are licensed under the {{licence_href}}. If you want to use it in ways prohibited by this license, please contact me and ask my permission."
+        :author => "This demo app was written by %{mail_1}.",
+        :feedback => "If you have any feedback, please feel free to drop me a line. Also visit %{blog_href} where I regularly blog about Rails and other stuff.",
+        :licence => "This demo app and all its contents are licensed under the %{licence_href}. If you want to use it in ways prohibited by this license, please contact me and ask my permission."
       },
       :active_record => {
         :too_lazy => "No examples here since I'm too lazy to think of attributes to show <strong>all</strong> custom error messages. ;-)",
@@ -103,17 +103,17 @@
       },
       :index => {
         :others => "others",
-        :introduction => "Lately, a lot of work has been done by {{sven_blog}} and {{sven_github}} to facilitate future internationalization and localization of Rails.",
+        :introduction => "Lately, a lot of work has been done by %{sven_blog} and %{sven_github} to facilitate future internationalization and localization of Rails.",
         :story_so_far => "This demo app tries to show you how you can use the features that have been implemented so far to localize big parts of your Rails application."
       },
       :number_helper => {
-        :note_one => "Note: <code>number_to_phone</code> hasn't been localized yet and probably never will be - at least not in core. Look out for new internationalization/localization plugins like a new version of {{globalize}} as they will probably support stuff like that.",
+        :note_one => "Note: <code>number_to_phone</code> hasn't been localized yet and probably never will be - at least not in core. Look out for new internationalization/localization plugins like a new version of %{globalize} as they will probably support stuff like that.",
         :note_two => "Another note: <code>number_to_currency</code>, <code>number_to_percentage</code> and <code>number_to_human_size</code> all use <code>number_with_precision</code> internally and <code>number_with_precision</code> uses <code>number_with_delimiter</code> internally."
       },
       :setup => {
         :freezing_edge_and_adding => "Freezing Edge and installing the localized_dates plugin",
         :you_need_to_be_on_edge => "You need to be on Edge Rails in order to use the Rails i18n features:",
-        :date_time_formats => "For date and time formats, you also need to install the {{localized_dates_link}}:",
+        :date_time_formats => "For date and time formats, you also need to install the %{localized_dates_link}:",
         :config_locale => "Configuring the locale",
         :best_place => "The best place to put your locale configuration, in my opinion, is <code>config/locales</code>. The localized_dates plugin will copy two locales, en-US and de-AT, in this directory. You can extend or modify them and also create new locales.",
         :locale => "Here's the demo locale that was used for this demo application:",
@@ -146,12 +146,12 @@
       :footer_message => "Copyright © 2010 <a href=\"http://www.caelum.com.br\">Caelum</a>",
       :created_by     => "código criado por",
       :moderator      => "Moderador",
-      :count_topics   => {:one => "<span class=\"bignum\">1</span> discussão", :other => "<span class=\"bignum\">{{count}}</span> discussões"},
-      :count_posts    => {:one => "<span class=\"bignum\">1</span> mensagem", :other => "<span class=\"bignum\">{{count}}</span> mensagens"},
+      :count_topics   => {:one => "<span class=\"bignum\">1</span> discussão", :other => "<span class=\"bignum\">%{count}</span> discussões"},
+      :count_posts    => {:one => "<span class=\"bignum\">1</span> mensagem", :other => "<span class=\"bignum\">%{count}</span> mensagens"},
       :my_topics      => "Minhas discussões",
       :new_topic      => "Nova discussão",
-      :post_age       => "{{when}} atrás",
-      :by_user        => "por {{user}}",
+      :post_age       => "%{when} atrás",
+      :by_user        => "por %{user}",
       :view           => "ler",
       :views_forums   => {
         :unmoderated  => "Este fórum não é moderado."
@@ -180,7 +180,7 @@
       :post_topic       => "Criar discussão",
       :monitor_topic    => "Monitorar discussão",
       :monitoring_topic => "Monitorando discussão",
-      :count_voices     => {:one => "1 participante", :other => "{{count}} participantes"},
+      :count_voices     => {:one => "1 participante", :other => "%{count} participantes"},
       :voices           => "Participantes",
       :reply_to_topic   => "Responder",
       :save_changes     => "Salvar alterações",
@@ -221,7 +221,7 @@
 
       # Posts
       :recent_posts       => "Mensagens recentes",
-      :count_posts_found  => {:zero => "nenhuma mensagem", :one => "1 mensagem", :other => "{{count}} mensagens" },
+      :count_posts_found  => {:zero => "nenhuma mensagem", :one => "1 mensagem", :other => "%{count} mensagens" },
       :topic              => "Discussão",
       :forum              => "Fórum",
       :post_updated       => "Mensagem modificada com sucesso",
@@ -247,7 +247,7 @@
       # Missing on User#show
       :all => "todas",
       :monitored => "monitoradas",
-      :user_since => "cadastrado em {{date}}",
+      :user_since => "cadastrado em %{date}",
       
       :password_confirm      => "Confirmação de Senha",
       :openid_url            => "URL do OpenID (opcional)",
@@ -261,9 +261,9 @@
       :user_unsuspended      => "O usuário não está mais suspenso.",
       :user_active           => "ativo",
       :user_pending          => "pendente",
-      :count_users           => {:zero => "nenhum usuário", :one => "1 usuário", :other => "{{num}} usuários" },
-      :count_users_active    => {:zero => "nenhum usuário ativo", :one => "1 usuário ativo", :other => "{{num}} usuários ativos" },
-      :count_users_lurking   => {:zero => "nenhum usuário escondido", :one => "1 usuário escondido", :other => "{{num}} usuários escondidos" },
+      :count_users           => {:zero => "nenhum usuário", :one => "1 usuário", :other => "%{num} usuários" },
+      :count_users_active    => {:zero => "nenhum usuário ativo", :one => "1 usuário ativo", :other => "%{num} usuários ativos" },
+      :count_users_lurking   => {:zero => "nenhum usuário escondido", :one => "1 usuário escondido", :other => "%{num} usuários escondidos" },
       :login_or_signup_and_comment     => "Faça o login",
       :user_is_administrator => "Administrador",
       :select_responsability => 'Selecione a responsabilidade',
@@ -299,7 +299,7 @@
         :sig_title                 => "Assinatura",
         :update_profile            => "Salvar perfil",
         :avatars_title             => "Avatar",
-        :gravatar_notice           => "Para ter seu avatar exibido neste fórum, registre-se no {{gravatar}}.",
+        :gravatar_notice           => "Para ter seu avatar exibido neste fórum, registre-se no %{gravatar}.",
 
         :find_a_user               => "Busca de Usuários",
         :search_title              => "Procurar",

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -26,47 +26,47 @@
       half_a_minute: 'meio minuto'
       less_than_x_seconds:
         one: 'menos de 1 segundo'
-        other: 'menos de {{count}} segundos'
+        other: 'menos de %{count} segundos'
 
       x_seconds:
         one: '1 segundo'
-        other: '{{count}} segundos'
+        other: '%{count} segundos'
 
       less_than_x_minutes:
         one: 'menos de um minuto'
-        other: 'menos de {{count}} minutos'
+        other: 'menos de %{count} minutos'
 
       x_minutes:
         one: '1 minuto'
-        other: '{{count}} minutos'
+        other: '%{count} minutos'
 
       about_x_hours:
         one: 'aproximadamente 1 hora'
-        other: 'aproximadamente {{count}} horas'
+        other: 'aproximadamente %{count} horas'
 
       x_days:
         one: '1 dia'
-        other: '{{count}} dias'
+        other: '%{count} dias'
 
       about_x_months:
         one: 'aproximadamente 1 mês'
-        other: 'aproximadamente {{count}} meses'
+        other: 'aproximadamente %{count} meses'
 
       x_months:
         one: '1 mês'
-        other: '{{count}} meses'
+        other: '%{count} meses'
 
       about_x_years:
         one: 'aproximadamente 1 ano'
-        other: 'aproximadamente {{count}} anos'
+        other: 'aproximadamente %{count} anos'
 
       over_x_years:
         one: 'mais de 1 ano'
-        other: 'mais de {{count}} anos'
+        other: 'mais de %{count} anos'
 
       almost_x_years:
         one: 'quase 1 ano'
-        other: 'quase {{count}} anos'
+        other: 'quase %{count} anos'
 
     prompts:
       year:   "Ano"
@@ -122,8 +122,8 @@
     errors:
       template:
         header:
-          one: "Não foi possível gravar {{model}}: 1 erro"
-          other: "Não foi possível gravar {{model}}: {{count}} erros."
+          one: "Não foi possível gravar %{model}: 1 erro"
+          other: "Não foi possível gravar %{model}: %{count} erros."
         body: "Por favor, verifique o(s) seguinte(s) campo(s):"
       messages:
         inclusion: "não está incluído na lista"
@@ -133,18 +133,18 @@
         accepted: "deve ser aceito"
         empty: "não pode ficar vazio"
         blank: "não pode ficar em branco"
-        too_long: "é muito longo (máximo: {{count}} caracteres)"
-        too_short: "é muito curto (mínimo: {{count}} caracteres)"
-        wrong_length: "não possui o tamanho esperado ({{count}} caracteres)"
+        too_long: "é muito longo (máximo: %{count} caracteres)"
+        too_short: "é muito curto (mínimo: %{count} caracteres)"
+        wrong_length: "não possui o tamanho esperado (%{count} caracteres)"
         taken: "já está em uso"
         not_a_number: "não é um número"
-        greater_than: "deve ser maior do que {{count}}"
-        greater_than_or_equal_to: "deve ser maior ou igual a {{count}}"
-        equal_to: "deve ser igual a {{count}}"
-        less_than: "deve ser menor do que {{count}}"
-        less_than_or_equal_to: "deve ser menor ou igual a {{count}}"
+        greater_than: "deve ser maior do que %{count}"
+        greater_than_or_equal_to: "deve ser maior ou igual a %{count}"
+        equal_to: "deve ser igual a %{count}"
+        less_than: "deve ser menor do que %{count}"
+        less_than_or_equal_to: "deve ser menor ou igual a %{count}"
         odd: "deve ser ímpar"
         even: "deve ser par"
-        record_invalid: "A validação falhou: {{errors}}"
+        record_invalid: "A validação falhou: %{errors}"
 
 # Original de http://github.com/svenfuchs/rails-i18n/tree/master/rails/locale

--- a/config/preinitializer.rb
+++ b/config/preinitializer.rb
@@ -1,0 +1,20 @@
+begin
+  require "rubygems"
+  require "bundler"
+rescue LoadError
+  raise "Could not load the bundler gem. Install it with `gem install bundler`."
+end
+
+if Gem::Version.new(Bundler::VERSION) <= Gem::Version.new("0.9.24")
+  raise RuntimeError, "Your bundler version is too old for Rails 2.3." +
+   "Run `gem install bundler` to upgrade."
+end
+
+begin
+  # Set up load paths for all bundled gems
+  ENV["BUNDLE_GEMFILE"] = File.expand_path("../../Gemfile", __FILE__)
+  Bundler.setup
+rescue Bundler::GemNotFound
+  raise RuntimeError, "Bundler couldn't find some gems." +
+    "Did you run `bundle install`?"
+end

--- a/vendor/plugins/active_record_context/lib/technoweenie/active_record_context.rb
+++ b/vendor/plugins/active_record_context/lib/technoweenie/active_record_context.rb
@@ -38,7 +38,7 @@ module Technoweenie
       end
       
       def find_every_with_context(options)
-        returning find_every_without_context(options) do |records|
+        find_every_without_context(options).tap do |records|
           store_in_context records
         end
       end


### PR DESCRIPTION
Atualizado para rails 2.3.11 e atualizado instruções do readme para conter todas as gems que não estão declaradas no environment.rb.

Os arquivos de internacionalização foram atualizados também para serem compatíveis com %{var} no lugar de {{var}} da versão anterior.
